### PR TITLE
fixes the projects component styling for safari

### DIFF
--- a/src/components/Projects.js
+++ b/src/components/Projects.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import RickAndMorty from '../img/projects/logo-RickAndMorty.svg';
 import CrushIt from '../img/projects/crush-it-logo.svg';
-import ForeverHomes from '../img/projects/foreverhomes-logo.svg';
 import ReactTube from '../img/projects/reacttube-logo.svg';
 import ReactUnsplash from '../img/projects/reactunsplash-logo.svg';
 

--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -317,8 +317,6 @@ section {
 }
 
 .projects {
-  display: flex;
-  flex-direction: column;
   background-color: $projects-background-color;
   background-image: $splotch-background;
   background-repeat: no-repeat;


### PR DESCRIPTION
closes #20 

The .projects class had flex and flex-direction that was causing issues with Safari on Desktop & Mobile.

Also removes unused import from removed project.