### PR TITLE
closes #21 - adds anchor tag global styling

### DIFF
--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -56,6 +56,11 @@ p {
   line-height: 1.5em;
 }
 
+a {
+  text-decoration: none;
+  font-size: inherit;
+}
+
 section {
   padding: 30px 60px 60px 60px;
   @include respond-to($breakpoint-medium) {


### PR DESCRIPTION
This adds global anchor tag styling, which inherits font size and removes text-decoration.