### PR TITLE
closes #26 - experience card refactor with text wrapping around the i…

### DIFF
--- a/src/components/ExperienceCard.js
+++ b/src/components/ExperienceCard.js
@@ -3,7 +3,7 @@ import React from 'react';
 const ExperienceCard = ({cardImage, cardImageAlt, cardUrl, children}) => {
 
 	return (
-    <div className="experience-card flex-container flex-direction-row">
+    <div className="experience-card">
         <div className="experience-card--image-container">
           <a 
             className="experience-card--link" href={cardUrl} target="_blank"

--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -264,21 +264,22 @@ section {
       justify-content: space-between;
       border-radius: $border-radius;
       box-shadow: $box-shadow;
+      text-align: left;
     
       @include respond-to($breakpoint-medium) {
         flex-direction: column;
       }
 
       .experience-card--image-container {
+        float: left;
         width: 45%;
+        margin: 0 20px 10px 0;
       
         @include respond-to($breakpoint-medium) {
           width: 60%;
-          margin: auto;
         }
         @include respond-to($breakpoint-x-small) {
           width: 100%;
-          margin: auto;
         }
         
         .experience-card--image {
@@ -290,12 +291,10 @@ section {
       
       .experience-card--description {
         text-align: left;
-        width: 50%;
         margin: 0;
       
         @include respond-to($breakpoint-medium) {
           width: 100%;
-          margin: 2rem 0;
         }
 
         h3 {
@@ -308,19 +307,6 @@ section {
         }
       }
     }
-    // .experience-card::after {
-    //   z-index: -1;
-    //   display: block;
-    //   position: absolute;
-    //   content: ' ';
-    //   -webkit-filter: url('#blur');
-    //   filter: url('#blur');
-    //   -webkit-filter: blur(5px);
-    //   filter: blur(5px);
-    //   background-size: cover;
-    //   opacity: 0.75;
-    //   background-color: $white;
-    // }
   }
 }
 


### PR DESCRIPTION
…mage

# Description
The experience card text now wraps around the card image, by using `float: left`.

## Screenshot
<img width="1146" alt="Screen Shot 2021-12-03 at 2 24 20 PM" src="https://user-images.githubusercontent.com/8608152/144680913-95a03823-baf9-4187-9631-377b0804acec.png">
