### PR TITLE
[development] updates styles for Connect

### DIFF
--- a/src/components/Portfolio/Connect/Connect.js
+++ b/src/components/Portfolio/Connect/Connect.js
@@ -15,7 +15,7 @@ const Connect = ({ data }) => {
   };
 
   return (
-    <section className='connect'>
+    <section id='connect' className='connect'>
       <div className='connect-header'>
         <img
           className='connect-image'
@@ -29,7 +29,7 @@ const Connect = ({ data }) => {
             src={data.background.circle.source}
             alt={data.background.circle.alt}
             animate={{ rotate: [0, 360] }}
-            transition={{ duration: 7, repeat: Infinity }}
+            transition={{ duration: 5, repeat: Infinity }}
           />
         </div>
         <div className='connect-content'>
@@ -41,8 +41,8 @@ const Connect = ({ data }) => {
             />
             <div className='connect-card-foreground'>
               <div className='connect-card'>
-                <h3>Hire Me</h3>
-                <aside>let me help you</aside>
+                <h3>{data.subheader}</h3>
+                <aside>{data.aside}</aside>
                 <div className='connect-icons-container'>
                   {data.icons.map((contact, index) => (
                     <a

--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -654,7 +654,7 @@
   }
 
   .connect {
-    margin-bottom: 10rem;
+    margin-bottom: 9rem;
     .connect-header {
       display: flex;
       justify-content: center;
@@ -663,7 +663,8 @@
         // max-width: 30rem;
         width: 100%;
         // margin: auto;
-        margin-bottom: 2rem;
+        margin-bottom: 4rem;
+        z-index: 10;
         @include respond-to($breakpoint-medium) {
           max-width: 20rem;
         }
@@ -691,13 +692,13 @@
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        min-height: 800px;
-        max-width: 400px;
+        min-height: 900px;
+        max-width: 500px;
         width: 100%;
         // background-image: $glass-background-image;
         img.profile-pic {
           width: 100%;
-          max-width: 200px;
+          max-width: 250px;
           background-color: gray;
           border-radius: 100%;
           border: #fae9cd solid 1rem;
@@ -707,15 +708,15 @@
         }
       }
       .connect-card-foreground {
+        width: 100%;
         height: 100%;
-        min-height: 600px;
+        min-height: 650px;
         // background-color: #fae9cd;
         border-radius: 0 0 $border-radius-primary $border-radius-primary;
         background-image: url('../img/portfolio/connect/connect-card-background.svg');
         background-repeat: no-repeat;
         background-position: top;
         background-size: cover;
-        width: 100%;
         .connect-card {
           width: 100%;
           height: 100%;
@@ -725,7 +726,7 @@
           align-items: center;
           h3 {
             color: $black;
-            margin-top: 100px;
+            margin-top: 115px;
           }
           aside {
             color: $black;
@@ -734,13 +735,13 @@
             display: flex;
             justify-content: space-evenly;
             align-items: center;
-            height: 17rem;
-            margin: 0 auto auto;
-            padding: 0 1rem;
             width: 100%;
+            height: 17rem;
+            padding: 0 1rem;
+            margin: 0 auto auto;
             .connect-icon {
-              max-width: 5rem;
               width: 100%;
+              max-width: 5rem;
               justify-self: center;
               align-items: center;
               color: $black;
@@ -763,7 +764,7 @@
             }
           }
           button {
-            max-width: 315px;
+            width: 75%;
             color: $white;
             font-size: 2rem;
             line-height: 1;
@@ -796,6 +797,7 @@
       align-items: center;
       img {
         overflow-x: clip;
+        width: 800px;
       }
     }
   }


### PR DESCRIPTION
# Description
the Mobile Styling for Connect looked a bit off. 
I increased the width of the card & the circle background.
Added some margin to the connect heading.
Also added an ID to the Connect section, so I can include links directly to that heading.

## Screenshots

<img width="535" alt="Screenshot 2024-01-19 at 9 29 44 AM" src="https://github.com/JasonToups/jasontoups.github.io/assets/8608152/8ba4230b-6545-48f4-a061-3752909a82b1">

## Develop & Deploy

- [x] test locally
- [x] Link the ticket to this PR
- [ ] merge PR
- [ ] switch branches back to main
- [ ] pull latest changes
- [ ] test locally
- [ ] deploy code to gh-pages
- [ ] test on Production
